### PR TITLE
Add NeoVim-GTK configuration.

### DIFF
--- a/CONFIG/home/USER_PLACEHOLDER/.config/nvim-gtk/plugs.toml
+++ b/CONFIG/home/USER_PLACEHOLDER/.config/nvim-gtk/plugs.toml
@@ -1,0 +1,1 @@
+enabled = false

--- a/CONFIG/home/USER_PLACEHOLDER/.config/nvim-gtk/window.toml
+++ b/CONFIG/home/USER_PLACEHOLDER/.config/nvim-gtk/window.toml
@@ -1,0 +1,5 @@
+current_width = 800
+current_height = 600
+is_maximized = true
+show_sidebar = false
+sidebar_width = 200

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ More detailed help is available by `bin/setup -h`.
 ## Installaled
 
 ## Configured
+
+- [NeoVim-GTK](https://github.com/daa84/neovim-gtk)

--- a/bin/setup
+++ b/bin/setup
@@ -100,6 +100,7 @@ EOS
 }
 
 do_symlinking() {
+  symlink_configuration "neovim-gtk" "nvim-gtk"
 }
 
 symlink_configuration() {


### PR DESCRIPTION
# Overview

Add configuration files for [NeoVim-GTK](https://github.com/daa84/neovim-gtk) which is GTK front-end for [NeoVim](https://neovim.io/). Create symbolic links to configuration in repository when `bin/setup` is launched.

# Changes

- Add configuration files for [NeoVim-GTK](https://github.com/daa84/neovim-gtk)
- Implement symbolic link creation from target system to configuration files in repository for neovim-gtk configuration. Configuration itself is under `nvim-gtk` directory.
- Add [NeoVim-GTK[(https://github.com/daa84/neovim-gtk) to the list of configured software in `README.md`.

# Pull Requests
- https://github.com/zekefast/dotfiles/pull/1 (merge before current)